### PR TITLE
Update information for NY.pm

### DIFF
--- a/perl_mongers.xml
+++ b/perl_mongers.xml
@@ -16,17 +16,17 @@
       <latitude>40.72426868</latitude>
     </location>
     <email type="group">
-      <user>nypm</user>
-      <domain>ny.pm.org</domain>
+      <user>nypm-organizers</user>
+      <domain>googlegroups.com</domain>
     </email>
     <tsar>
-      <name>David H. Adler</name>
+      <name>NY.pm Organizers Committee</name>
       <email type="personal">
-        <user>dha</user>
-        <domain>panix.com</domain>
+        <user>nypm-organizers</user>
+        <domain>googlegroups.com</domain>
       </email>
     </tsar>
-    <web>http://ny.pm.org/</web>
+    <web>http://www.meetup.com/The-New-York-Perl-Meetup-Group/</web>
     <meetup>http://www.meetup.com/The-New-York-Perl-Meetup-Group/</meetup>
     <mailing_list>
       <name>General NY.pm discussion</name>


### PR DESCRIPTION
PerlSemNY.pm and NY.pm have been folded together, and we've been working by committee for some time now, and just created a google group to facilitate that process.  I've updated the document to reflect that.
