### PR TITLE
Please add Niceville pm as a new Perl Mongers group.

### DIFF
--- a/perl_mongers.xml
+++ b/perl_mongers.xml
@@ -19013,4 +19013,27 @@
     <web>http://fleet.pm.org</web>
     <date type="inception">20150603</date>
   </group>
+
+  <group id="787" status="active">
+    <name>Niceville.pm</name>
+    <location>
+      <city>Niceville</city>
+      <state></state>
+      <region></region>
+      <country>United States of America</country>
+      <continent>North America</continent>
+      <longitude>-86.481011</longitude>
+      <latitude>30.519338</latitude>
+    </location>
+    <tsar>
+      <name>Thomas M. Browder, Jr.</name>
+      <email type="personal">
+        <user>tom.browder</user>
+        <domain>gmail.com</domain>
+      </email>
+    </tsar>
+    <web>http://niceville.pm.org</web>
+    <date type="inception">20150629</date>
+  </group>
+
 </perl_mongers>


### PR DESCRIPTION
Here is the IP address I wish you to point to (which is my own bare-metal server which will be hosting our new NPM site as one of several virtual sites):
  142.54.186.2
The domain will be: <niceville.pm.org>.

Please host a Mailman mailing list for us (i.e., host Mailman mailing list: YES).

Thanks!