### PR TITLE
Changed Purdue.pm URL

### DIFF
--- a/perl_mongers.xml
+++ b/perl_mongers.xml
@@ -5275,7 +5275,7 @@
         <domain>live.com</domain>
       </email>
     </tsar>
-    <web>http://purdue.pm.org/</web>
+    <web>http://purdue.pl/</web>
     <date type="inception">19991024</date>
   </group>
   <group id="239" status="undef">


### PR DESCRIPTION
Changed perl_mongers.xml to point pm.org to the new Purdue Perl Mongers site, purdue.pl.