### PR TITLE
added canonical to sort the JSON

### DIFF
--- a/bin/xml
+++ b/bin/xml
@@ -345,7 +345,7 @@ foreach my $continent (@continents) {
 
     # Get the perl_monger data as json, makes the map stuff easier
     my $j    = JSON->new->utf8;
-    my $json = $j->pretty->encode( \@allgroups );
+    my $json = $j->pretty->canonical->encode( \@allgroups );
     write_file( "$www/groups/perl_mongers.json", $json );
 
 }


### PR DESCRIPTION
I found out about this working with another problem, but if, when you use ->pretty, you also add ->canonical, it sorts the keys.
