### PR TITLE
Update information for Amsterdam.pm

### DIFF
--- a/perl_mongers.xml
+++ b/perl_mongers.xml
@@ -2633,10 +2633,10 @@
       <name>Jan-Pieter Cornet</name>
       <email type="personal">
         <user>monger</user>
-        <domain>amsterdam.pm.org</domain>
+        <domain>cornet.org</domain>
       </email>
     </tsar>
-    <web>http://amsterdam.pm.org/</web>
+    <web>https://amsterdam.pm.org/</web>
     <date type="inception">19980826</date>
   </group>
   <group id="115" status="undef">


### PR DESCRIPTION
We would like to "hand back" control of DNS for the zone 'amsterdam.pm.org'
(currently delegated to 'xs4all.nl')

The answer to the questions:
1) a CNAME to pnl.test-smoke.org
2) no mailinglist for the moment