### PR TITLE
change Lat,Lon and 301 redirect

### DIFF
--- a/perl_mongers.xml
+++ b/perl_mongers.xml
@@ -300,8 +300,8 @@
       <region></region>
       <country>United States of America</country>
       <continent>North America</continent>
-      <longitude>-71.085055</longitude>
-      <latitude>42.361065</latitude>
+      <longitude>-70.92</longitude>
+      <latitude>42.35</latitude>
     </location>
     <tsar>
       <name>Bill Ricker</name>


### PR DESCRIPTION
Moving Lat,Lon from MIT classroom building to Boston Harbor
as we're pure virtual for the time being and MIT is not
reopening to outside groups. :-(

Our free Wiki provider was worth every penny, failed.
Current redirect is flagged as unsafe since DNS-squatter grabbed
their domain.

New 301 redirect please
boston.pm.org ⇒ https://boston-pm.github.io/

(we'll eventually request proper DNS to a proper server
and this address will be the staging server but for now
this is working.)

The second half of this PR comment duplicates Issue #169 .